### PR TITLE
Fix-[Client/Server] Cyr not working

### DIFF
--- a/JEasyCryptoClient/src/CryptoClient.java
+++ b/JEasyCryptoClient/src/CryptoClient.java
@@ -136,7 +136,8 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("id", requestId++);
 		request.put("operation", "capabilities");
 		String data = request.toJSONString();
-		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
+		byte[] serializedData = data.getBytes();
+		DatagramPacket packet = new DatagramPacket(serializedData, serializedData.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
 	
@@ -149,7 +150,8 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("method", method);
 		request.put("data", text);
 		String data = request.toJSONString();
-		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
+		byte[] serializedData = data.getBytes();
+		DatagramPacket packet = new DatagramPacket(serializedData, serializedData.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
 	
@@ -162,7 +164,8 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("method", method);
 		request.put("data", text);
 		String data = request.toJSONString();
-		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
+		byte[] serializedData = data.getBytes();
+		DatagramPacket packet = new DatagramPacket(serializedData, serializedData.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
 	

--- a/JEasyCryptoClient/src/CryptoClient.java
+++ b/JEasyCryptoClient/src/CryptoClient.java
@@ -1,12 +1,12 @@
 import java.io.Console;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import org.json.simple.JSONObject;
-
 
 public class CryptoClient implements Runnable, ReaderObserver {
 
@@ -136,7 +136,7 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("id", requestId++);
 		request.put("operation", "capabilities");
 		String data = request.toJSONString();
-		byte[] serializedData = data.getBytes();
+		byte[] serializedData = data.getBytes(StandardCharsets.UTF_16);
 		DatagramPacket packet = new DatagramPacket(serializedData, serializedData.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
@@ -150,7 +150,7 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("method", method);
 		request.put("data", text);
 		String data = request.toJSONString();
-		byte[] serializedData = data.getBytes();
+		byte[] serializedData = data.getBytes(StandardCharsets.UTF_16);
 		DatagramPacket packet = new DatagramPacket(serializedData, serializedData.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
@@ -164,7 +164,7 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("method", method);
 		request.put("data", text);
 		String data = request.toJSONString();
-		byte[] serializedData = data.getBytes();
+		byte[] serializedData = data.getBytes(StandardCharsets.UTF_16);
 		DatagramPacket packet = new DatagramPacket(serializedData, serializedData.length, serverAddr, serverPort);
 		socket.send(packet);
 	}

--- a/JEasyCryptoClient/src/ResponseReader.java
+++ b/JEasyCryptoClient/src/ResponseReader.java
@@ -1,4 +1,5 @@
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 
@@ -27,7 +28,7 @@ public class ResponseReader extends Thread {
 				System.out.println("Starting to receive responses...");
 				socket.receive(packet);
 				System.out.println("Response received.");
-				String receivedData = new String(packet.getData(), 0, packet.getLength());
+				String receivedData = new String(packet.getData(), 0, packet.getLength(),StandardCharsets.UTF_16);
 				System.out.println("Received raw data: " + receivedData);
 				System.out.println("Parsing...");
 				JSONObject root = (JSONObject) new JSONParser().parse(receivedData);

--- a/JEasyCryptoClient/src/ResponseReader.java
+++ b/JEasyCryptoClient/src/ResponseReader.java
@@ -28,7 +28,7 @@ public class ResponseReader extends Thread {
 				System.out.println("Starting to receive responses...");
 				socket.receive(packet);
 				System.out.println("Response received.");
-				String receivedData = new String(packet.getData(), 0, packet.getLength(),StandardCharsets.UTF_16);
+				String receivedData = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_16);
 				System.out.println("Received raw data: " + receivedData);
 				System.out.println("Parsing...");
 				JSONObject root = (JSONObject) new JSONParser().parse(receivedData);

--- a/JEasyCryptoServer/src/CryptoServer.java
+++ b/JEasyCryptoServer/src/CryptoServer.java
@@ -1,5 +1,6 @@
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -79,7 +80,8 @@ public class CryptoServer implements Runnable {
 				} finally {
 					if (null != response && null != sender) {
 						System.out.println("Sending response: " + response);
-						DatagramPacket sendPacket = new DatagramPacket(response.getBytes(), response.length());
+						byte[] serializedResponse = response.getBytes();
+						DatagramPacket sendPacket = new DatagramPacket(serializedResponse, serializedResponse.length);
 						sendPacket.setAddress(sender);
 						sendPacket.setPort(packet.getPort());
 						try {

--- a/JEasyCryptoServer/src/CryptoServer.java
+++ b/JEasyCryptoServer/src/CryptoServer.java
@@ -44,7 +44,7 @@ public class CryptoServer implements Runnable {
 					System.out.println("Start to receive packets...");
 					socket.receive(packet);
 					System.out.println("Packet received!");
-					String receivedData = new String(packet.getData(), 0, packet.getLength());
+					String receivedData = new String(packet.getData(), 0, packet.getLength(), StandardCharsets.UTF_16);
 					sender = packet.getAddress();
 					System.out.println("Sender is: " + sender.getHostAddress() + ":" + packet.getPort());
 					System.out.println("Received raw data: " + receivedData);
@@ -80,7 +80,7 @@ public class CryptoServer implements Runnable {
 				} finally {
 					if (null != response && null != sender) {
 						System.out.println("Sending response: " + response);
-						byte[] serializedResponse = response.getBytes();
+						byte[] serializedResponse = response.getBytes(StandardCharsets.UTF_16);
 						DatagramPacket sendPacket = new DatagramPacket(serializedResponse, serializedResponse.length);
 						sendPacket.setAddress(sender);
 						sendPacket.setPort(packet.getPort());


### PR DESCRIPTION
#### What does this PR do?
In the communication between client and server the data is trimmed. The error is caused because an incorect length is specified when the DatagramPacket is created. The code before fix used the length of the data string. This did not match the length of the byte array which is actually transmitted. This has been fixed by using the correct length in the DatagramPacket constructor.

#### Where should the reviewer start?
All the usage of DatagramPacket constructor in the CryptoClient.java and CryptoServer.java

#### How should this be manually tested?
1. Test Cyr encrypt/decrypt in Client/Server mode. Now no exception is thrown

#### Any background context you want to provide?
The string.getBytes() might have a different length than the actual string.

#### What are the relevant tickets?
Closes #7 

#### Screenshots
None

#### Questions
None