### PR TITLE
Fix [Client/Server] Exotic character break the encryption #8

### DIFF
--- a/JEasyCryptoClient/src/CryptoClient.java
+++ b/JEasyCryptoClient/src/CryptoClient.java
@@ -1,7 +1,5 @@
 import java.io.Console;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;

--- a/JEasyCryptoClient/src/CryptoClient.java
+++ b/JEasyCryptoClient/src/CryptoClient.java
@@ -1,5 +1,7 @@
 import java.io.Console;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
@@ -29,6 +31,7 @@ public class CryptoClient implements Runnable, ReaderObserver {
 	public void run() {
 		// Prepare variables.
 		try {
+
 			socket = new DatagramSocket(10001);
 			
 			serverAddr = queryServerAddress();
@@ -149,7 +152,8 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("method", method);
 		request.put("data", text);
 		String data = request.toJSONString();
-		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
+		byte[] dataToSend = data.getBytes("utf-8");
+		DatagramPacket packet = new DatagramPacket(dataToSend, dataToSend.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
 	
@@ -162,7 +166,8 @@ public class CryptoClient implements Runnable, ReaderObserver {
 		request.put("method", method);
 		request.put("data", text);
 		String data = request.toJSONString();
-		DatagramPacket packet = new DatagramPacket(data.getBytes(), data.length(), serverAddr, serverPort);
+		byte[] dataToSend = data.getBytes("utf-8");
+		DatagramPacket packet = new DatagramPacket(dataToSend, dataToSend.length, serverAddr, serverPort);
 		socket.send(packet);
 	}
 	

--- a/JEasyCryptoServer/src/CryptoServer.java
+++ b/JEasyCryptoServer/src/CryptoServer.java
@@ -43,7 +43,7 @@ public class CryptoServer implements Runnable {
 					System.out.println("Start to receive packets...");
 					socket.receive(packet);
 					System.out.println("Packet received!");
-					String receivedData = new String(packet.getData(), 0, packet.getLength());
+					String receivedData = new String(packet.getData(), packet.getOffset(), packet.getLength(), "utf-8");
 					sender = packet.getAddress();
 					System.out.println("Sender is: " + sender.getHostAddress() + ":" + packet.getPort());
 					System.out.println("Received raw data: " + receivedData);
@@ -79,7 +79,8 @@ public class CryptoServer implements Runnable {
 				} finally {
 					if (null != response && null != sender) {
 						System.out.println("Sending response: " + response);
-						DatagramPacket sendPacket = new DatagramPacket(response.getBytes(), response.length());
+						byte[] responseToSend = response.getBytes();
+						DatagramPacket sendPacket = new DatagramPacket(responseToSend, responseToSend.length);
 						sendPacket.setAddress(sender);
 						sendPacket.setPort(packet.getPort());
 						try {


### PR DESCRIPTION
#### What does this PR do?
It changes the type of data the Datagrampacket send from String to byte[]. This fixes the problem encountered where sent data's length got cut short. 

#### Where should the reviewer start?
From the client where the data is sent, and from the server where the data is received.

#### Any background context you want to provide?
Patch also adds utf-8 encoding to client and server to prevent mismatches between them. 

#### What are the relevant tickets?
Closes #8 