### PR TITLE
Fix for windows build issue #22

### DIFF
--- a/JEasyCrypto/build.cmd
+++ b/JEasyCrypto/build.cmd
@@ -1,0 +1,7 @@
+javac -d bin src\easycrypto\*.java
+cd bin
+jar cvf ..\..\EasyCryptoLib.jar easycrypto\*.class
+cd ..
+exit
+
+

--- a/JEasyCryptoClient/build.cmd
+++ b/JEasyCryptoClient/build.cmd
@@ -1,0 +1,3 @@
+javac src\*.java -classpath "..\json-simple-1.1.1.jar;." -d bin
+exit
+

--- a/JEasyCryptoClient/start.cmd
+++ b/JEasyCryptoClient/start.cmd
@@ -1,0 +1,2 @@
+java -cp ..\json-simple-1.1.1.jar;bin;. CryptoClient
+

--- a/JEasyCryptoConsole/build.cmd
+++ b/JEasyCryptoConsole/build.cmd
@@ -1,0 +1,2 @@
+javac src\EasyCryptoConsole\*.java -classpath "..\EasyCryptoLib.jar;." -d bin
+exit

--- a/JEasyCryptoConsole/start.cmd
+++ b/JEasyCryptoConsole/start.cmd
@@ -1,0 +1,1 @@
+java -cp ../EasyCryptoLib.jar;bin;. EasyCryptoConsole/EasyCryptoConsole

--- a/JEasyCryptoServer/build.cmd
+++ b/JEasyCryptoServer/build.cmd
@@ -1,0 +1,2 @@
+javac src\*.java -classpath "..\EasyCryptoLib.jar;..\json-simple-1.1.1.jar;." -d bin
+exit

--- a/JEasyCryptoServer/start.cmd
+++ b/JEasyCryptoServer/start.cmd
@@ -1,0 +1,2 @@
+java -cp ..\EasyCryptoLib.jar;..\json-simple-1.1.1.jar;bin;. CryptoServer
+

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,12 @@
+cd JEasyCrypto
+start /B /WAIT build.cmd
+cd ..
+cd .\JEasyCryptoClient
+start /B /WAIT build.cmd
+cd ..
+cd .\JEasyCryptoConsole
+start /B /WAIT build.cmd
+cd ..
+cd .\JEasyCryptoServer
+start /B /WAIT build.cmd
+cd ..


### PR DESCRIPTION
Build and start script for windows added.

#### What does this PR do?
With this PR you can build JEasyCrypto components in windows environment and start server and client. 

#### Where should the reviewer start?
Check *.cmd files

#### How should this be manually tested?
1.  run build.cmd on JEasyCrypto folder it shall run all build on all subfolders.
2. run JEasyCrypto\JEasyCryptoServer\start.cmd
3. run EasyCrypto\JEasyCryptoClient\start.cmd

#### Any background context you want to provide?
Console probably will not start though...

#### What are the relevant tickets?
(Link to issues, related PR, etc.)
Closes #22

 

#### Questions
  Anyone has succeeded in running the console on windows?
