### PR TITLE
Bugfix empty string

### DIFF
--- a/JEasyCrypto/src/easycrypto/EasyCryptoAPI.java
+++ b/JEasyCrypto/src/easycrypto/EasyCryptoAPI.java
@@ -57,25 +57,29 @@ public class EasyCryptoAPI {
     @returns Returns success code of the encryption. See Result enum for details.
 	 */
 	public static Result encrypt(final String toEncrypt, final String method) {
-		try {
-			if (method.equalsIgnoreCase("reverse")) {
-				CryptoMethod theImpl = new ReverseMethod();
-				return theImpl.encrypt(toEncrypt);
-			} else if (method.equalsIgnoreCase("matrix")) {
-				CryptoMethod theImpl = new MatrixMethod();
-				return theImpl.encrypt(toEncrypt);
-			} else if (method.equalsIgnoreCase("cyr")) {
-				CryptoMethod theImpl = new CyrMethod();
-				return theImpl.encrypt(toEncrypt);
-			} else if (method.equalsIgnoreCase("rot13")){
-				CryptoMethod theImpl = new Rot13Method();
-				return theImpl.encrypt(toEncrypt);
-			}
+		if (toEncrypt!=null&&!toEncrypt.isEmpty()){
+			try {
+				if (method.equalsIgnoreCase("reverse")) {
+					CryptoMethod theImpl = new ReverseMethod();
+					return theImpl.encrypt(toEncrypt);
+				} else if (method.equalsIgnoreCase("matrix")) {
+					CryptoMethod theImpl = new MatrixMethod();
+					return theImpl.encrypt(toEncrypt);
+				} else if (method.equalsIgnoreCase("cyr")) {
+					CryptoMethod theImpl = new CyrMethod();
+					return theImpl.encrypt(toEncrypt);
+				} else if (method.equalsIgnoreCase("rot13")){
+					CryptoMethod theImpl = new Rot13Method();
+					return theImpl.encrypt(toEncrypt);
+				}
 
-		} catch (Exception e) {
-			return new Result(ResultCode.EError, e.getMessage());
+			} catch (Exception e) {
+				return new Result(ResultCode.EError, e.getMessage());
+			}
+			return new Result(ResultCode.ENotSupported, "Error: Method not supported!");
+		}else{
+			return new Result(ResultCode.EError,"Error: you cannot encrypt empty strings");
 		}
-		return new Result(ResultCode.ENotSupported, "Error: Method not supported!");
 	}
 
 	/**
@@ -86,26 +90,29 @@ public class EasyCryptoAPI {
     @returns Returns success code of the decryption. See Result enum for details.
 	 */
 	public static Result decrypt(final String toDecrypt, final String method) {
-		try {
-			if (method.equalsIgnoreCase("reverse")) {
-				CryptoMethod theImpl = new ReverseMethod();
-				return theImpl.decrypt(toDecrypt);
-			} else if (method.equalsIgnoreCase("matrix")) {
-				CryptoMethod theImpl = new MatrixMethod();
-				return theImpl.decrypt(toDecrypt);
-			} else if (method.equalsIgnoreCase("cyr")) {
-				CryptoMethod theImpl = new CyrMethod();
-				return theImpl.decrypt(toDecrypt);
-			}else if (method.equalsIgnoreCase("rot13")){
-				CryptoMethod theImpl = new Rot13Method();
-				return theImpl.decrypt(toDecrypt);
+		if (toEncrypt!=null&&!toEncrypt.isEmpty()){
+			try {
+				if (method.equalsIgnoreCase("reverse")) {
+					CryptoMethod theImpl = new ReverseMethod();
+					return theImpl.decrypt(toDecrypt);
+				} else if (method.equalsIgnoreCase("matrix")) {
+					CryptoMethod theImpl = new MatrixMethod();
+					return theImpl.decrypt(toDecrypt);
+				} else if (method.equalsIgnoreCase("cyr")) {
+					CryptoMethod theImpl = new CyrMethod();
+					return theImpl.decrypt(toDecrypt);
+				}else if (method.equalsIgnoreCase("rot13")){
+					CryptoMethod theImpl = new Rot13Method();
+					return theImpl.decrypt(toDecrypt);
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+				return new Result(ResultCode.EError, e.getMessage());
 			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			return new Result(ResultCode.EError, e.getMessage());
+			return new Result(ResultCode.ENotSupported, "Error: Method not supported!");
+		}else{
+			return new Result(ResultCode.EError,"Error: you cannot decrypt empty strings");
 		}
-
-		return new Result(ResultCode.ENotSupported, "Error: Method not supported!");
 	}
 
 	/** To query the version of the library.

--- a/JEasyCrypto/src/easycrypto/EasyCryptoAPI.java
+++ b/JEasyCrypto/src/easycrypto/EasyCryptoAPI.java
@@ -67,7 +67,11 @@ public class EasyCryptoAPI {
 			} else if (method.equalsIgnoreCase("cyr")) {
 				CryptoMethod theImpl = new CyrMethod();
 				return theImpl.encrypt(toEncrypt);
+			} else if (method.equalsIgnoreCase("rot13")){
+				CryptoMethod theImpl = new Rot13Method();
+				return theImpl.encrypt(toEncrypt);
 			}
+
 		} catch (Exception e) {
 			return new Result(ResultCode.EError, e.getMessage());
 		}
@@ -91,6 +95,9 @@ public class EasyCryptoAPI {
 				return theImpl.decrypt(toDecrypt);
 			} else if (method.equalsIgnoreCase("cyr")) {
 				CryptoMethod theImpl = new CyrMethod();
+				return theImpl.decrypt(toDecrypt);
+			}else if (method.equalsIgnoreCase("rot13")){
+				CryptoMethod theImpl = new Rot13Method();
 				return theImpl.decrypt(toDecrypt);
 			}
 		} catch (Exception e) {
@@ -121,6 +128,8 @@ public class EasyCryptoAPI {
 			method = new MatrixMethod();
 			methods += method.method();
 			method = new CyrMethod();
+			methods += "," + method.method();
+			method = new Rot13Method();
 			methods += "," + method.method();
 		} catch (Exception e) {
 			// ....

--- a/JEasyCrypto/src/easycrypto/Rot13Method.java
+++ b/JEasyCrypto/src/easycrypto/Rot13Method.java
@@ -1,0 +1,42 @@
+package easycrypto;
+
+import easycrypto.EasyCryptoAPI.Result;
+import easycrypto.EasyCryptoAPI.ResultCode;
+
+class Rot13Method implements CryptoMethod {
+
+  @Override
+  public Result encrypt(final String toEncrypt){
+    String res="";
+    char c='a';
+    for (int i=0;i<toEncrypt.length();i++){
+      c=toEncrypt.charAt(i);
+      if (Character.isLowerCase(c)){
+        c=((c<(int)'n') ? (c+=13) : (c-=13));
+      } else{
+        c=((c<(int)'N') ? (c+=13) : (c-=13));
+      }
+      res=res+c;
+    }
+    return new Result(ResultCode.ESuccess,res);
+  }
+  @Override
+  public Result decrypt(final String toDecrypt){
+    String res="";
+    char c='a';
+    for (int i=0;i<toDecrypt.length();i++){
+      c=toDecrypt.charAt(i);
+      if (Character.isLowerCase(c)){
+        c=((c>=(int)'n') ? (c-=13) : (c+=13));
+      } else{
+        c=((c>=(int)'N') ? (c-=13) : (c+=13));
+      }
+      res=res+c;
+    }
+    return new Result(ResultCode.ESuccess,res);
+  }
+  @Override
+  public String method(){
+    return "rot13";
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
fixes the empty-string possibility for encrypt/decrypt methods. Returns to the user that "Don't use empty strings" should the user try it. Doesn't crash on local machine.

#### Where should the reviewer start?
All changes are made in JEasyCryptoAPI file. Added a check which if successful does the encryption, else returns the error message to the user.

#### How should this be manually tested?
start program normally and test with empty strings.